### PR TITLE
Fix build error about SDL header searching

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ else()
 
     target_include_directories(Game
         PRIVATE
-        "${SDL2_INCLUDE_DIR}"
+        "${SDL2_INCLUDE_DIR}/.."
     )
     target_link_libraries(Game
         PRIVATE


### PR DESCRIPTION
It will fix the [CI build error](https://ci.appveyor.com/project/Kerndog73/entt-example/builds/246889320),  
```
$ cmake --build .
Scanning dependencies of target Game
[  6%] Building CXX object CMakeFiles/Game.dir/src/main.cpp.o
/Users/lineplus/Project/sample/EnTT-Pacman/src/main.cpp:12:10: fatal error:
      'SDL2/SDL_main.h' file not found
#include <SDL2/SDL_main.h>
         ^~~~~~~~~~~~~~~~~
1 error generated.
make[2]: *** [CMakeFiles/Game.dir/src/main.cpp.o] Error 1
make[1]: *** [CMakeFiles/Game.dir/all] Error 2
make: *** [all] Error 2
```