### PR TITLE
Include utility header for std::as_const()

### DIFF
--- a/src/util/grid.hpp
+++ b/src/util/grid.hpp
@@ -11,6 +11,7 @@
 
 #include <vector>
 #include <cassert>
+#include <utility>
 #include "pos.hpp"
 
 template <typename Elem>


### PR DESCRIPTION
The source file does not compile on GNU/Linux. My environments are as follows:
```
$ g++ --version
g++ (GCC) 10.2.0
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

$ cmake --version
cmake version 3.19.1

CMake suite maintained and supported by Kitware (kitware.com/cmake).
```

During compilation, the following error is generated:
```
$ cmake -S . -B build/
-- The C compiler identification is GNU 10.2.0
-- The CXX compiler identification is GNU 10.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/cc - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/c++ - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
Finding SDL2
-- Looking for pthread.h
-- Looking for pthread.h - found
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Failed
-- Looking for pthread_create in pthreads
-- Looking for pthread_create in pthreads - not found
-- Looking for pthread_create in pthread
-- Looking for pthread_create in pthread - found
-- Found Threads: TRUE  
-- Found SDL2: /usr/lib/libSDL2main.a;/usr/lib/libSDL2.so;-lpthread  
-- Configuring done
-- Generating done
-- Build files have been written to: /home/phil/git/EnTT-Pacman/build

$ cd build && make
Scanning dependencies of target pacman
[  5%] Building CXX object CMakeFiles/pacman.dir/src/core/app.cpp.o
In file included from /home/phil/git/EnTT-Pacman/src/core/maze.hpp:13,
                 from /home/phil/git/EnTT-Pacman/src/core/game.hpp:13,
                 from /home/phil/git/EnTT-Pacman/src/core/app.cpp:13:
/home/phil/git/EnTT-Pacman/src/util/grid.hpp: In member function ‘Elem& Grid<Elem>::operator[](std::size_t)’:
/home/phil/git/EnTT-Pacman/src/util/grid.hpp:47:36: error: ‘as_const’ is not a member of ‘std’; did you mean ‘is_const’?
   47 |     return const_cast<Elem &>(std::as_const(*this)[i]);
      |                                    ^~~~~~~~
      |                                    is_const
/home/phil/git/EnTT-Pacman/src/util/grid.hpp: In member function ‘Elem& Grid<Elem>::operator[](Pos)’:
/home/phil/git/EnTT-Pacman/src/util/grid.hpp:51:36: error: ‘as_const’ is not a member of ‘std’; did you mean ‘is_const’?
   51 |     return const_cast<Elem &>(std::as_const(*this)[pos]);
      |                                    ^~~~~~~~
      |                                    is_const
make[2]: *** [CMakeFiles/pacman.dir/build.make:82: CMakeFiles/pacman.dir/src/core/app.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:95: CMakeFiles/pacman.dir/all] Error 2
make: *** [Makefile:103: all] Error 2
```

The cause of this error is that `std::as_const()` requires the `utility` header to be included, which is it is not in `src/util/grid.hpp`. This PR adds the required header and it now compiles on my machine.
